### PR TITLE
Use fixed format for risk/reward ratio table

### DIFF
--- a/rr_ratio_table.pine
+++ b/rr_ratio_table.pine
@@ -1,0 +1,14 @@
+//@version=5
+indicator("RR Ratio Table", overlay=true)
+
+// Example risk/reward ratio
+float rr_ratio = 1.2345
+
+// Create a table
+var table rr_table = table.new(position.top_right, 1, 1, frame_color=color.new(color.black, 0), frame_width=1)
+
+// Convert ratio to text using fixed-format string to ensure consistent decimal places
+string rr_text = str.tostring(rr_ratio, format="#.##")
+
+if barstate.islast
+    table.cell(rr_table, 0, 0, rr_text)


### PR DESCRIPTION
## Summary
- Display risk/reward ratio in table using fixed `"#.##"` format for consistent decimal places.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc6a1282083319f09716e1a70b804