### PR TITLE
Add conditional risk/reward ratio and fallback display

### DIFF
--- a/risk_reward_example.pine
+++ b/risk_reward_example.pine
@@ -1,0 +1,15 @@
+//@version=5
+indicator("Risk/Reward Demo", overlay=true)
+
+stop = close - 100
+profit = close + 200
+
+risk = close - stop
+reward = profit - close
+rr_ratio = risk != 0 ? reward / risk : na
+
+var table stats = table.new(position.top_right, 2, 1, border_width=1)
+if barstate.islast
+    table.cell(stats, 0, 0, "R/R", text_color=color.white, bgcolor=color.blue)
+    rr_text = na(rr_ratio) ? "—" : str.tostring(rr_ratio, format.mintick)
+    table.cell(stats, 1, 0, rr_text, text_color=color.white, bgcolor=color.blue)


### PR DESCRIPTION
## Summary
- compute risk/reward ratio only when risk is non-zero
- display a fallback symbol when risk/reward ratio is unavailable

## Testing
- `rg 'rr_ratio' -n`


------
https://chatgpt.com/codex/tasks/task_e_688fc696c87c83319ee8f86acbe9b9d2