### PR TITLE
Align table header colors with snippet

### DIFF
--- a/LeverageTradingCalculator.pine
+++ b/LeverageTradingCalculator.pine
@@ -76,11 +76,11 @@ if barstate.islast
     table.cell(t, 1, 4, "$" + str.tostring(take_profit, format.mintick), text_color=color.green, text_halign=text.align_left)
 
     // SL row highlighted when unsafe
-    table.cell(t, 0, 5, "SL", text_color=color.white, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 0) : color.new(color.black, 0))
+    table.cell(t, 0, 5, "SL", text_color=color.yellow, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 0) : color.new(color.black, 0))
     table.cell(t, 1, 5, (sl_unsafe ? "⚠️ " : "") + "$" + str.tostring(stop_loss, format.mintick), text_color=sl_unsafe ? color.white : color.yellow, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 0) : color.new(color.black, 0))
 
     // Liq row also highlighted when unsafe
-    table.cell(t, 0, 6, "Liq", text_color=color.white, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 15) : color.new(color.black, 0))
+    table.cell(t, 0, 6, "Liq", text_color=color.red, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 15) : color.new(color.black, 0))
     table.cell(t, 1, 6, "$" + str.tostring(liq_price, format.mintick), text_color=sl_unsafe ? color.white : color.red, text_halign=text.align_left, bgcolor=sl_unsafe ? color.new(color.red, 15) : color.new(color.black, 0))
 
     table.cell(t, 0, 7, "Profit", text_color=color.green, text_halign=text.align_left)


### PR DESCRIPTION
## Summary
- update SL header text color to yellow
- update Liq header text color to red

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_688fd59582248331a043965fc5c129c3